### PR TITLE
Added --no-relocate to luggage.make

### DIFF
--- a/luggage.make
+++ b/luggage.make
@@ -70,7 +70,7 @@ PAYLOAD_D=${SCRATCH_D}/payload
 # --no-recommend. You can disable this by overriding PM_EXTRA_ARGS in your
 # package's Makefile.
 
-PM_EXTRA_ARGS=--verbose --no-recommend
+PM_EXTRA_ARGS=--verbose --no-recommend --no-relocate
 
 # Override if you want to require a restart after installing your package.
 PM_RESTART=None


### PR DESCRIPTION
prototype.plist has IFPkgFlagRelocatable set to false. Added "--no-relocate" to the packagemaker parameters to be 100% sure that packagemaker will disable automatic relocation of package contents.
