### PR TITLE
Allow packages to install to volumes other than root.

### DIFF
--- a/luggage.make
+++ b/luggage.make
@@ -72,6 +72,8 @@ PAYLOAD_D=${SCRATCH_D}/payload
 
 PM_EXTRA_ARGS=--verbose --no-recommend --no-relocate
 
+# Set to false if you want your package to install to volumes other than the boot volume
+ROOT_ONLY=true
 # Override if you want to require a restart after installing your package.
 PM_RESTART=None
 PAYLOAD=
@@ -219,7 +221,8 @@ ${PACKAGE_PLIST}: /usr/local/share/luggage/prototype.plist
 		sed "s/{PACKAGE_ID}/${PACKAGE_ID}/g" | \
 		sed "s/{PACKAGE_VERSION}/${PACKAGE_VERSION}/g" | \
 		sed "s/{PM_RESTART}/${PM_RESTART}/g" | \
-	        sed "s/{PLIST_FLAVOR}/${PLIST_FLAVOR}/g" \
+        sed "s/{PLIST_FLAVOR}/${PLIST_FLAVOR}/g" | \
+           	sed "s/{ROOT_ONLY}/${ROOT_ONLY}/g" \
 		> .luggage.pkg.plist
 	@sudo ${CP} .luggage.pkg.plist ${SCRATCH_D}/luggage.pkg.plist
 	@rm .luggage.pkg.plist ${PACKAGE_PLIST}

--- a/prototype.plist
+++ b/prototype.plist
@@ -31,7 +31,7 @@
 	<key>IFPkgFlagRestartAction</key>
 	<string>{PM_RESTART}</string>
 	<key>IFPkgFlagRootVolumeOnly</key>
-	<true/>
+	<{ROOT_ONLY}/>
 	<key>IFPkgFlagUpdateInstalledLanguages</key>
 	<false/>
 </dict>


### PR DESCRIPTION
luggage.make:
• Added variable to set IFPkgFlagRootVolumeOnly to true (default
behavior)
• Added sed command to update ROOT_ONLY in luggage.pkg.plist
prototype.plist
• Replaced "true" with "{ROOT_ONLY}" in IFPkgFlagRootVolumeOnly key
