### PR TITLE
Added a feature which allows you to specify that an existing copy of the application will not be overwritten.

### DIFF
--- a/app2luggage.rb
+++ b/app2luggage.rb
@@ -86,6 +86,7 @@ exit 0
 
 END_PREFLIGHT
     else
+        # GUI will just exit with error - as there is some issue with InstallationCheck and VolumeCheck picking up the target volume information
         if $opts[:no_overwrite] then
             rawPreflight =<<"END_PREFLIGHT"
 #!/bin/bash


### PR DESCRIPTION
Looked into using VolumeCheck and InstallationCheck. However, there were errors with these approaches during testing. It seemed that the install destination volume was not being passed. So instead I decided to place the checks into the preflight script. This means that no message of any value is presented within the GUI install. However, it means that targets other than / are supported.
