### PR TITLE
Better filtering defaults, explicit pseudo_payload

### DIFF
--- a/luggage.make
+++ b/luggage.make
@@ -73,7 +73,7 @@ PAYLOAD_D=${SCRATCH_D}/payload
 # package's Makefile.
 
 PM_EXTRA_ARGS=--verbose --no-recommend --no-relocate
-PM_FILTER=--filter "/CVS$$" --filter "/\.svn$$" --filter "/\.cvsignore$$" --filter "/\.cvspass$$" --filter "/\.DS_Store$$" --filter "/\.git$$" --filter "/\.gitignore$$"
+M_FILTER=--filter "/CVS$$" --filter "/\.svn$$" --filter "/\.cvsignore$$" --filter "/\.cvspass$$" --filter "/(\._)?\.DS_Store$$" --filter "/\.git$$" --filter "/\.gitignore$$"
 
 # Set to false if you want your package to install to volumes other than the boot volume
 ROOT_ONLY=true


### PR DESCRIPTION
After having built a package directly from a subversion directory, i noticed the filters for .svn were missing. I changed luggage.make to contain the current PackageMaker defaults and also added git filters.

In addition, one can override PM_FILTER in every Makefile to explicitly control filtering for a given project.

Also, the "harmless" payload has been moved into it's own stanza to allow for explicit overrides; so that you easily leave out that payload if your package does not need it. Rather cosmetic, but i like my packages clean...
