### PR TITLE
Fix Typo in PM_FILTER

### DIFF
--- a/luggage.make
+++ b/luggage.make
@@ -73,7 +73,7 @@ PAYLOAD_D=${SCRATCH_D}/payload
 # package's Makefile.
 
 PM_EXTRA_ARGS=--verbose --no-recommend --no-relocate
-M_FILTER=--filter "/CVS$$" --filter "/\.svn$$" --filter "/\.cvsignore$$" --filter "/\.cvspass$$" --filter "/(\._)?\.DS_Store$$" --filter "/\.git$$" --filter "/\.gitignore$$"
+PM_FILTER=--filter "/CVS$$" --filter "/\.svn$$" --filter "/\.cvsignore$$" --filter "/\.cvspass$$" --filter "/(\._)?\.DS_Store$$" --filter "/\.git$$" --filter "/\.gitignore$$"
 
 # Set to false if you want your package to install to volumes other than the boot volume
 ROOT_ONLY=true


### PR DESCRIPTION
Sorry, i had a typo my previous pull request. Instead of PM_FILTER the variable name was set to M_FILTER with a net effect that no filters are applied at all. Fixed now.
