### PR TITLE
Modified /var to /private/var

### DIFF
--- a/luggage.make
+++ b/luggage.make
@@ -267,6 +267,20 @@ l_private_etc: l_private
 	@sudo chown -R root:wheel ${WORK_D}/private/etc
 	@sudo chmod -R 755 ${WORK_D}/private/etc
 
+l_private_var: l_var
+
+l_private_var_lib: l_var_lib
+
+l_private_var_lib_puppet: l_var_lib_puppet
+
+l_private_var_db: l_var_db
+
+l_private_var_root: l_var_root
+
+l_private_var_root_Library: l_var_root_Library
+
+l_private_var_root_Library_Preferences: l_var_root_Library_Preferences
+
 l_etc_hooks: l_private_etc
 	@sudo mkdir -p ${WORK_D}/private/etc/hooks
 	@sudo chown -R root:wheel ${WORK_D}/private/etc/hooks
@@ -392,40 +406,40 @@ l_usr_share_doc: l_usr_share
 	@sudo chown -R root:wheel ${WORK_D}/usr/share/doc
 	@sudo chmod -R 755 ${WORK_D}/usr/share/doc
 
-l_var: l_root
-	@sudo mkdir -p ${WORK_D}/var
-	@sudo chown -R root:wheel ${WORK_D}/var
-	@sudo chmod -R 755 ${WORK_D}/var
+l_var: l_private
+	@sudo mkdir -p ${WORK_D}/private/var
+	@sudo chown -R root:wheel ${WORK_D}/private/var
+	@sudo chmod -R 755 ${WORK_D}/private/var
 
 l_var_lib: l_root
-	@sudo mkdir -p ${WORK_D}/var/lib
-	@sudo chown -R root:wheel ${WORK_D}/var/lib
-	@sudo chmod -R 755 ${WORK_D}/var/lib
+	@sudo mkdir -p ${WORK_D}/private/var/lib
+	@sudo chown -R root:wheel ${WORK_D}/private/var/lib
+	@sudo chmod -R 755 ${WORK_D}/private/var/lib
 
 l_var_lib_puppet: l_root
-	@sudo mkdir -p ${WORK_D}/var/lib/puppet
-	@sudo chown -R root:wheel ${WORK_D}/var/lib/puppet
-	@sudo chmod -R 755 ${WORK_D}/var/lib/puppet
+	@sudo mkdir -p ${WORK_D}/private/var/lib/puppet
+	@sudo chown -R root:wheel ${WORK_D}/private/var/lib/puppet
+	@sudo chmod -R 755 ${WORK_D}/private/var/lib/puppet
 
 l_var_db: l_var
-	@sudo mkdir -p ${WORK_D}/var/db
-	@sudo chown -R root:wheel ${WORK_D}/var/db
-	@sudo chmod -R 755 ${WORK_D}/var/db
+	@sudo mkdir -p ${WORK_D}/private/var/db
+	@sudo chown -R root:wheel ${WORK_D}/private/var/db
+	@sudo chmod -R 755 ${WORK_D}/private/var/db
 
 l_var_root: l_var
-	@sudo mkdir -p ${WORK_D}/var/root
-	@sudo chown -R root:wheel ${WORK_D}/var/root
-	@sudo chmod -R 750 ${WORK_D}/var/root
+	@sudo mkdir -p ${WORK_D}/private/var/root
+	@sudo chown -R root:wheel ${WORK_D}/private/var/root
+	@sudo chmod -R 750 ${WORK_D}/private/var/root
 
 l_var_root_Library: l_var_root
-	@sudo mkdir -p ${WORK_D}/var/root/Library
-	@sudo chown -R root:wheel ${WORK_D}/var/root/Library
-	@sudo chmod -R 700 ${WORK_D}/var/root/Library
+	@sudo mkdir -p ${WORK_D}/private/var/root/Library
+	@sudo chown -R root:wheel ${WORK_D}/private/var/root/Library
+	@sudo chmod -R 700 ${WORK_D}/private/var/root/Library
 
 l_var_root_Library_Preferences: l_var_root_Library
-	@sudo mkdir -p ${WORK_D}/var/root/Library/Preferences
-	@sudo chown -R root:wheel ${WORK_D}/var/root/Library/Preferences
-	@sudo chmod -R 700 ${WORK_D}/var/root/Library/Preferences
+	@sudo mkdir -p ${WORK_D}/private/var/root/Library/Preferences
+	@sudo chown -R root:wheel ${WORK_D}/private/var/root/Library/Preferences
+	@sudo chmod -R 700 ${WORK_D}/private/var/root/Library/Preferences
 
 l_Applications: l_root
 	@sudo mkdir -p ${WORK_D}/Applications
@@ -684,8 +698,8 @@ pack-usr-local-bin-%: % l_usr_local_bin
 pack-usr-local-sbin-%: % l_usr_local_sbin
 	@sudo ${INSTALL} -m 755 -g wheel -o root $< ${WORK_D}/usr/local/sbin
 
-pack-var-root-Library-Preferences-%: % l_var_root_Library_Preferences
-	@sudo ${INSTALL} -m 600 -g wheel -o root $< ${WORK_D}/var/root/Library/Preferences
+pack-var-root-Library-Preferences-%: % l_private_var_root_Library_Preferences
+	@sudo ${INSTALL} -m 600 -g wheel -o root $< ${WORK_D}/private/var/root/Library/Preferences
 
 pack-man-%: l_usr_man
 	@sudo ${INSTALL} -m 0644 -g wheel -o root $< ${WORK_D}/usr/share/man


### PR DESCRIPTION
Modified /var to /private/var. Updated various location dependencies. Added convenience locations starting with l_private_var. Kept support for l_var locations to avoid breaking existing user Makefiles.

Tested with modified pack-var-root-Library-Preferences-% packaging rule.
