### PR TITLE
Add support for pkgbuild

### DIFF
--- a/luggage.make
+++ b/luggage.make
@@ -172,7 +172,7 @@ package_root:
 # packagemaker chokes if the pkg doesn't contain any payload, making script-only
 # packages fail to build mysteriously if you don't remember to include something
 # in it, so we're including the /usr/local directory, since it's harmless.
-# this psuedo_payload can be easily overriden in your Makefile
+# this pseudo_payload can easily be overridden in your makefile
 
 pseudo_payload: l_usr_local
 


### PR DESCRIPTION
Add support for pkgbuild. To use, add USE_PKGBUILD=1 to your Makefile (or override for everything in luggage.local), and ensure your package scripts are correctly named (preinstall/postinstall in the brave new pkgbuild world).

Also tweak location of luggage.local import, and ensure environment variables are preserved so $STAMP and other time-sensitive variables aren't re-evaluated in sub-makes.
