### PR TITLE
Added Oracle Java Application Support directories and packaging rules.

### DIFF
--- a/luggage.make
+++ b/luggage.make
@@ -638,20 +638,20 @@ l_System_Library_Extensions: l_System_Library
 	@sudo chmod -R 755 ${WORK_D}/System/Library/Extensions
 
 l_System_Library_User_Template: l_System_Library
-	@sudo mkdir -p ${WORK_D}/System/Library/User\ Template/English.lproj
-	@sudo chown -R root:wheel ${WORK_D}/System/Library/User\ Template/English.lproj
-	@sudo chmod 700 ${WORK_D}/System/Library/User\ Template
-	@sudo chmod -R 755 ${WORK_D}/System/Library/User\ Template/English.lproj
+	@sudo mkdir -p ${USER_TEMPLATE}/English.lproj
+	@sudo chown -R root:wheel ${USER_TEMPLATE}/English.lproj
+	@sudo chmod 700 ${USER_TEMPLATE}
+	@sudo chmod -R 755 ${USER_TEMPLATE}/English.lproj
 
 l_System_Library_User_Template_Library: l_System_Library_User_Template
-	@sudo mkdir -p ${WORK_D}/System/Library/User\ Template/English.lproj/Library
-	@sudo chown root:wheel ${WORK_D}/System/Library/User\ Template/English.lproj/Library
-	@sudo chmod 700 ${WORK_D}/System/Library/User\ Template/English.lproj/Library
+	@sudo mkdir -p ${USER_TEMPLATE}/English.lproj/Library
+	@sudo chown root:wheel ${USER_TEMPLATE}/English.lproj/Library
+	@sudo chmod 700 ${USER_TEMPLATE}/English.lproj/Library
 
 l_System_Library_User_Template_Pictures: l_System_Library_User_Template
-	@sudo mkdir -p ${WORK_D}/System/Library/User\ Template/English.lproj/Pictures
-	@sudo chown root:wheel ${WORK_D}/System/Library/User\ Template/English.lproj/Pictures
-	@sudo chmod 700 ${WORK_D}/System/Library/User\ Template/English.lproj/Pictures
+	@sudo mkdir -p ${USER_TEMPLATE_PICTURES}
+	@sudo chown root:wheel ${USER_TEMPLATE_PICTURES}
+	@sudo chmod 700 ${USER_TEMPLATE_PICTURES}
 
 l_System_Library_User_Template_Preferences: l_System_Library_User_Template_Library
 	@sudo mkdir -p ${USER_TEMPLATE_PREFERENCES}
@@ -659,39 +659,39 @@ l_System_Library_User_Template_Preferences: l_System_Library_User_Template_Libra
 	@sudo chmod -R 700 ${USER_TEMPLATE_PREFERENCES}
 
 l_System_Library_User_Template_Library_Application_Support: l_System_Library_User_Template_Library
-	@sudo mkdir -p ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support
-	@sudo chown root:wheel ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support
-	@sudo chmod 700 ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support
+	@sudo mkdir -p ${USER_TEMPLATE}/English.lproj/Library/Application\ Support
+	@sudo chown root:wheel ${USER_TEMPLATE}/English.lproj/Library/Application\ Support
+	@sudo chmod 700 ${USER_TEMPLATE}/English.lproj/Library/Application\ Support
 
 l_System_Library_User_Template_Library_Application_Support_Firefox: l_System_Library_User_Template_Library_Application_Support
-	@sudo mkdir -p ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support/Firefox
-	@sudo chown root:wheel ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support/Firefox
-	@sudo chmod 700 ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support/Firefox
+	@sudo mkdir -p ${USER_TEMPLATE}/English.lproj/Library/Application\ Support/Firefox
+	@sudo chown root:wheel ${USER_TEMPLATE}/English.lproj/Library/Application\ Support/Firefox
+	@sudo chmod 700 ${USER_TEMPLATE}/English.lproj/Library/Application\ Support/Firefox
 
 l_System_Library_User_Template_Library_Application_Support_Firefox_Profiles: l_System_Library_User_Template_Library_Application_Support_Firefox
-	@sudo mkdir -p ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support/Firefox/Profiles
-	@sudo chown root:wheel ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support/Firefox/Profiles
-	@sudo chmod 700 ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support/Firefox/Profiles
+	@sudo mkdir -p ${USER_TEMPLATE}/English.lproj/Library/Application\ Support/Firefox/Profiles
+	@sudo chown root:wheel ${USER_TEMPLATE}/English.lproj/Library/Application\ Support/Firefox/Profiles
+	@sudo chmod 700 ${USER_TEMPLATE}/English.lproj/Library/Application\ Support/Firefox/Profiles
 
 l_System_Library_User_Template_Library_Application_Support_Firefox_Profiles_Default: l_System_Library_User_Template_Library_Application_Support_Firefox_Profiles
-	@sudo mkdir -p ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support/Firefox/Profiles/a7e8aa9f.default
-	@sudo chown root:wheel ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support/Firefox/Profiles/a7e8aa9f.default
-	@sudo chmod 700 ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support/Firefox/Profiles/a7e8aa9f.default
+	@sudo mkdir -p ${USER_TEMPLATE}/English.lproj/Library/Application\ Support/Firefox/Profiles/a7e8aa9f.default
+	@sudo chown root:wheel ${USER_TEMPLATE}/English.lproj/Library/Application\ Support/Firefox/Profiles/a7e8aa9f.default
+	@sudo chmod 700 ${USER_TEMPLATE}/English.lproj/Library/Application\ Support/Firefox/Profiles/a7e8aa9f.default
 
 l_System_Library_User_Template_Library_Application_Support_Oracle: l_System_Library_User_Template_Library
-	@sudo mkdir -p ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support/Oracle
-	@sudo chown root:wheel ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support/Oracle
-	@sudo chmod 700 ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support/Oracle
+	@sudo mkdir -p ${USER_TEMPLATE}/English.lproj/Library/Application\ Support/Oracle
+	@sudo chown root:wheel ${USER_TEMPLATE}/English.lproj/Library/Application\ Support/Oracle
+	@sudo chmod 700 ${USER_TEMPLATE}/English.lproj/Library/Application\ Support/Oracle
 
 l_System_Library_User_Template_Library_Application_Support_Oracle_Java: l_System_Library_User_Template_Library_Application_Support_Oracle
-	@sudo mkdir -p ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support/Oracle/Java
-	@sudo chown root:wheel ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support/Oracle/Java
-	@sudo chmod 700 ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support/Oracle/Java
+	@sudo mkdir -p ${USER_TEMPLATE}/English.lproj/Library/Application\ Support/Oracle/Java
+	@sudo chown root:wheel ${USER_TEMPLATE}/English.lproj/Library/Application\ Support/Oracle/Java
+	@sudo chmod 700 ${USER_TEMPLATE}/English.lproj/Library/Application\ Support/Oracle/Java
 
 l_System_Library_User_Template_Library_Application_Support_Oracle_Java_Deployment: l_System_Library_User_Template_Library_Application_Support_Oracle_Java
-	@sudo mkdir -p ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support/Oracle/Java/Deployment
-	@sudo chown root:wheel ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support/Oracle/Java/Deployment
-	@sudo chmod 700 ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support/Oracle/Java/Deployment
+	@sudo mkdir -p ${USER_TEMPLATE}/English.lproj/Library/Application\ Support/Oracle/Java/Deployment
+	@sudo chown root:wheel ${USER_TEMPLATE}/English.lproj/Library/Application\ Support/Oracle/Java/Deployment
+	@sudo chmod 700 ${USER_TEMPLATE}/English.lproj/Library/Application\ Support/Oracle/Java/Deployment
 
 # These user domain locations are for use in rare circumstances, and
 # as a last resort only for repackaging applications that use them.
@@ -782,10 +782,10 @@ pack-user-picture-%: % l_Library_Desktop_Pictures
 	@sudo ${INSTALL} -m 644 "${<}" ${WORK_D}/Library/Desktop\ Pictures
 
 pack-User-Template-Library-Application-Support-Firefox-Profiles-Default-%: % l_System_Library_User_Template_Library_Application_Support_Firefox_Profiles_Default
-	@sudo ${INSTALL} -m 644 "${<}" ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support/Firefox/Profiles/a7e8aa9f.default
+	@sudo ${INSTALL} -m 644 "${<}" ${USER_TEMPLATE}/English.lproj/Library/Application\ Support/Firefox/Profiles/a7e8aa9f.default
 
 pack-User-Template-Library-Application-Support-Oracle-Java-Deployment-%: % l_System_Library_User_Template_Library_Application_Support_Oracle_Java_Deployment
-	@sudo ${INSTALL} -m 644 -g wheel -o root "${<}" ${WORK_D}/System/Library/User\ Template/English.lproj/Library/Application\ Support/Oracle/Java/Deployment
+	@sudo ${INSTALL} -m 644 -g wheel -o root "${<}" ${USER_TEMPLATE}/English.lproj/Library/Application\ Support/Oracle/Java/Deployment
 
 # posixy file stanzas
 


### PR DESCRIPTION
Oracle Java support files, such as deployment.properties, can now be installed into the following two directories on the destination volume:
- /Library/Application Support/Oracle/Java/Deployment
- /System/Library/User Template/English.lproj/Library/Application Support/Oracle/Java/Deployment

Based on [Oracle documentation](http://docs.oracle.com/javase/1.5.0/docs/guide/deployment/deployment-guide/properties.html), this should allow for system- and user-level configuration files, respectively.
