### PR TITLE
add pkgls functionality for pkgbuild

### DIFF
--- a/luggage.make
+++ b/luggage.make
@@ -227,10 +227,21 @@ prep_pkg: clean compile_package
 
 pkg: prep_pkg local_pkg
 
-pkgls: prep_pkg
+ifeq (${USE_PKGBUILD}, 1)
+pkgls: pkgls_pb ;
+else
+pkgls: pkgls_pm ;
+endif
+
+pkgls_pm: prep_pkg
 	@echo
 	@echo
 	lsbom -p fmUG ${PAYLOAD_D}/${PACKAGE_FILE}/Contents/Archive.bom
+
+pkgls_pb: prep_pkg
+	@echo
+	@echo
+	lsbom -p fmUG `pkgutil --bom ${PAYLOAD_D}/${PACKAGE_FILE}`
 
 payload: payload_d package_root scratchdir scriptdir resourcedir
 	make -e ${PAYLOAD}


### PR DESCRIPTION
In a similar manner as previous conditionals, this splits pkgls to allow for the same verbose output displaying the bill of materials that was generated for bundle pkgs. Utilizes pkgutil’s —bom option to then pass it to lsbom for display.
Feedback/review appreciated as always. 🙇
