### PR TITLE
A couple of bug-fixes and an enhancement

### DIFF
--- a/luggage.make
+++ b/luggage.make
@@ -245,7 +245,7 @@ pkgls_pb: prep_pkg
 	lsbom -p fmUG `pkgutil --bom ${PAYLOAD_D}/${PACKAGE_FILE}`
 
 payload: payload_d package_root scratchdir scriptdir resourcedir
-	make -e ${PAYLOAD}
+	make -f $(word 1,$(MAKEFILE_LIST)) -e ${PAYLOAD}
 	@-echo
 
 compile_package_pm: payload .luggage.pkg.plist modify_packageroot


### PR DESCRIPTION
• I had trouble getting the relocation to stick, and found that using sudo was needed.
• There was also a PlistBuddy usage bug that meant the value never got set.
• Because I was previously using another tool for building packages, some of my folders have the contents of multiple packages within them. In order to build multiple packages I needed to be able to specify which Makefile to use, so I added that functionality.
