### PR TITLE
Makefile should gracefully handle the absence of PackageMaker.app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,10 @@ bootstrap_files: bootstrap_directory
 	@sudo ${INSTALL} -m 755 -o root -g wheel app2luggage.rb /usr/local/bin/app2luggage.rb
 	@if [ ! -x "/usr/local/bin/packagemaker" ]; then \
 		packagemaker=`find /Applications -name PackageMaker`; \
-		sudo ln -s $$packagemaker /usr/local/bin/packagemaker; \
+		if [ $$packagemaker ]; then \
+			echo "PackageMaker found!"; \
+			sudo ln -s $$packagemaker /usr/local/bin/packagemaker; \
+		fi \
 	fi
 
 bootstrap_directory:

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,6 @@ bootstrap_files: bootstrap_directory
 	@if [ ! -x "/usr/local/bin/packagemaker" ]; then \
 		packagemaker=`find /Applications -name PackageMaker`; \
 		if [ $$packagemaker ]; then \
-			echo "PackageMaker found!"; \
 			sudo ln -s $$packagemaker /usr/local/bin/packagemaker; \
 		fi \
 	fi


### PR DESCRIPTION
Since using pkgbuild is the default action, we should not assume that PackageMaker is installed when 'make bootstrap_files' is executed, but if present we should set up the sym link as we have been doing.